### PR TITLE
performance tuning: _copy and update_v3

### DIFF
--- a/lib/Nagios/StatusLog.pm
+++ b/lib/Nagios/StatusLog.pm
@@ -300,10 +300,7 @@ sub update_v1 ($) {
 # held in client code remain valid during update (also prevents
 # some memory leaks)
 sub _copy {
-    my ( $from, $to ) = @_;
-    foreach my $key ( keys %$from ) {
-        $to->{$key} = $from->{$key};
-    }
+    %{ $_[1] } = %{ $_[0] };
 }
 
 sub update_v2 ($) {
@@ -463,7 +460,10 @@ sub update_v3 ($) {
     my $type = 0;
     while ( my $line = <$log_fh> ) {
         next if ( $line =~ /^\s*#|^\s*$/ );
-        if ( $line =~ /^\s*(\w+)\s*{\s*$/ ) {
+        if ( $line =~ /\s*(\w+)=(.*)$/ ) {
+            $attributes{$1} = $2;
+        }
+        elsif ( $line =~ /^\s*(\w+)\s*{\s*$/ ) {
             %attributes = ();
             if (exists $valid_types{$1}) {
                 $type = $1;
@@ -471,14 +471,11 @@ sub update_v3 ($) {
                 $type = 0;
             }
         }
-        if ( $line =~ /^\s*}\s*$/ ) {
+        elsif ( $line =~ /^\s*}\s*$/ ) {
             # Only save the object if it is a valid type
             if ($type) {
                 $handlers{$type}->( \%attributes );
             }
-        }
-        if ( $line =~ /\s*(\w+)=(.*)$/ ) {
-            $attributes{$1} = $2;
         }
     }
 


### PR DESCRIPTION
_copy: no loop for keys

update_v3: First, check the most common format line (like: key=value), then
check other format line by "elsif" instead of "if".

Because my status.dat is over 900,000 lines, order of checking line is important.
