### PR TITLE
Call Scalar::Util::weaken for avoiding circular references

### DIFF
--- a/lib/Nagios/StatusLog.pm
+++ b/lib/Nagios/StatusLog.pm
@@ -22,6 +22,7 @@ use Carp;
 use strict qw( subs vars );
 use warnings;
 use Symbol;
+use Scalar::Util;
 
 # NOTE: due to CPAN version checks this cannot currently be changed to a
 # standard version string, i.e. '0.21'
@@ -556,6 +557,7 @@ sub service {
         if ( !$self->{SERVICE}{$host}{$service} );
 
     $self->{SERVICE}{$host}{$service}{__parent} = $self;
+    Scalar::Util::weaken($self->{SERVICE}{$host}{$service}{__parent});
     bless( $self->{SERVICE}{$host}{$service}, 'Nagios::Service::Status' );
 }
 
@@ -639,6 +641,7 @@ sub host {
         if ( !$self->{HOST}{$host} );
 
     $self->{HOST}{$host}{__parent} = $self;
+    Scalar::Util::weaken($self->{HOST}{$host}{__parent});
     bless( $self->{HOST}{$host}, 'Nagios::Host::Status' );
 }
 


### PR DESCRIPTION
When using this module (not calling "update") again and again in a program the memory consumption increased.
I investigated and found that there are circular references and the memory regions were not freed.
This patch weakens such references and I confirmed the memory consumption does not change however times I use this module.
