### PR TITLE
Ignore '+' sign at the beginning of member lists.

### DIFF
--- a/lib/Nagios/Object.pm
+++ b/lib/Nagios/Object.pm
@@ -855,6 +855,12 @@ sub _set ($ $ $) {
         $self->_validate( $key, $value, @{ $vf->{$key} } );
     }
 
+    # Nagios allows the usage of a '+' sign. This breaks member lists.
+    # Ignore the '+' sign completely for now.
+    if ( ref $vf->{$key}[0] eq 'ARRAY' && $value =~/^\+(.+)$/ ) {
+        $value = $1;
+    }
+
     if ( ref $vf->{$key}[0] eq 'ARRAY' && $value =~ /,/ ) {
         $value = [ split /\s*,\s*/, $value ];
     }


### PR DESCRIPTION
It seems to be valid to prefix member lists with a '+' sign which is ignored by the perl config parser. check-mk does this all the time:

`define host {
  host_name                     example
  use                           check_mk_host
  address                       a.b.c.d
  _TAGS                         foo bar
  _FILENAME                     /example.mk
  hostgroups                    +Example-Routers
  contact_groups                +Example-Contacts
}
  define hostgroup {
   hostgroup_name                Example-Routers
   alias                         Example-Routers
 }`

The perl parser does **not** add the host to the corresponding hostgroups/contactgroups due the prefixed '+' sign, but nagios is doing so. This breaks other tools parsing the configuration and rely on group memberships (i.e. smokegios).

The small patch just drops any prefix '+' sign on ARRAY like attributes. I did not find any documentation about the semantic of the '+' sign. So this patch is not realy a fix, but a workaround to get atleast some of the group assignments working.

HTH,
Thomas
