### PR TITLE
Implement multiple template inheritance

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -10,6 +10,7 @@ lib/Nagios/Config/File.pm
 lib/Nagios/Object.pm
 lib/Nagios/Object/Config.pm
 lib/Nagios/StatusLog.pm
+lib/Nagios/Template.pm
 MANIFEST
 MANIFEST.SKIP
 META.yml
@@ -46,6 +47,8 @@ t/nagios3config.t
 t/nagios4config.t
 t/nestedtemplates.cfg
 t/nestedtemplates.t
+t/multipletemplates.cfg
+t/multipletemplates.t
 t/sample-config-bigger.cfg
 t/sample-config-minimal.cfg
 t/sample-config-v3.cfg

--- a/lib/Nagios/Object/Config.pm
+++ b/lib/Nagios/Object/Config.pm
@@ -24,6 +24,7 @@ use Nagios::Object qw(:all %nagios_setup);
 use Scalar::Util qw(blessed);
 use File::Basename qw(dirname);
 use File::Find qw(find);
+use Nagios::Template;
 use Symbol;
 use Carp;
 
@@ -537,8 +538,9 @@ sub resolve {
         && defined $object->{use}
         && !exists $object->{_use} )
     {
-        my $template = $self->find_object( $object->use, ref $object );
-        $object->{_use} = $template;
+	$object->{_use} = new Nagios::Template(map {
+	    $self->find_object( $_, ref $object );
+	} split /\s*,\s*/, $object->use);
     }
 
     1;

--- a/lib/Nagios/Template.pm
+++ b/lib/Nagios/Template.pm
@@ -1,0 +1,71 @@
+package Nagios::Template;
+use strict;
+use warnings;
+use Carp;
+
+sub new {
+    my $class = shift;
+    return shift if @_ == 1;
+    bless { objects => [ @_ ] }, $class
+}
+
+sub objects { @{shift->{objects}} }
+
+sub can {
+    my ($self,$meth) = @_;
+    if (my $s = $self->SUPER::can($meth)) {
+	return $s;
+    }
+    foreach my $obj ($self->objects) {
+	if ($obj->can($meth)) {
+	    return $obj;
+	}
+    }
+}
+
+our $AUTOLOAD;
+sub AUTOLOAD {
+    my $self = shift;
+    $AUTOLOAD =~ s/(?:(.*)::)?(.+)//;
+    my ($p, $m) = ($1, $2);
+    foreach my $obj ($self->objects) {
+	if ($obj->can($m)) {
+	    if (defined(my $v = $obj->${\$m}(@_))) {
+		return $v;
+	    }
+	}
+    }
+    croak "Can't locate object method \"$m\" via package \"$p\"";
+}
+
+1;
+
+=head1 NAME
+    
+Nagios::Template - Perl object representing Nagios template
+
+=head1 NOTE
+
+Users of B<Nagios::Config> should never need to create objects of this
+class.  It is used internally by B<Nagios::Object::Config> to implement
+template inheritance.
+
+=head1 DESCRIPTOION
+
+The B<Nagios::Template> implements template inheritance.  The constructor
+takes as its arguments the list of Nagios objects representing the right-
+hand side of a "use" statement in Nagios configuration object.  If only
+one object is given (simple inheritance), the constructor returns the
+object transparently.  If given several arguments (multiple inheritance),
+a new instance of B<Nagios::Template> is returned.
+
+The set of attributes for an objects of this class is the union of attributes
+supported by the objects supplied to its constructor.  When an attribute
+is requested, the B<Nagios::Template> object iterates over its underlying
+objects and returns the first value defined.  This conforms with the
+behavior of Nagios as described in:
+
+L<https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectinheritance.html>
+
+=cut
+

--- a/t/multipletemplates.cfg
+++ b/t/multipletemplates.cfg
@@ -1,0 +1,25 @@
+# An example of multiple template inheritance taken from
+# https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectinheritance.html
+
+# Generic host template
+define host {
+	name 			generic-host
+	active_checks_enabled	1
+	check_interval		10
+	register 		0
+}
+
+# Development web server template
+define host {
+	name 			development-server
+	check_interval		15
+	notification_options	d,u,r
+	register 		0
+}
+
+# Development web server
+define host {
+	use			generic-host,development-server
+	host_name 		devweb1
+}
+

--- a/t/multipletemplates.t
+++ b/t/multipletemplates.t
@@ -1,0 +1,25 @@
+#!/usr/bin/perl -w
+
+use strict;
+use Test::More qw(no_plan);
+use Test::NoWarnings;
+use lib qw( ../lib ./lib );
+use Data::Dumper;
+
+$Data::Dumper::Terse = 1;
+$Data::Dumper::Indent = 0;
+
+eval { chdir('t') };
+
+use Nagios::Config;
+
+my $config = Nagios::Object::Config->new();
+$config->parse('multipletemplates.cfg');
+
+my $host = $config->find_object('devweb1','Nagios::Host');
+
+is($host->check_interval, 10, 'attribute defined in both parent templates');
+is($host->active_checks_enabled, 1, 'attribute defined in first parent template');
+is(Dumper([$host->notification_options]), q{[['d','u','r']]},
+   'attribute defined in second parent template');
+


### PR DESCRIPTION
Starting from Nagios 3, multiple objects can be listed in the right-hand side of the "use" configuration
statement.  This change implements multiple inheritance as described in 

  https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectinheritance.html

Short overview of the changes.

* MANIFEST: Add new files.
* lib/Nagios/Object/Config.pm (resolve): Store the reference to
a Nagios::Template object in $object->{_use}.
* lib/Nagios/Template.pm: New file.
* t/multipletemplates.cfg: New file.
* t/multipletemplates.t: New file.