### PR TITLE
Implement additive inheritance. Fix a bug in multiple inheritance imp…

### DIFF
--- a/lib/Nagios/Template.pm
+++ b/lib/Nagios/Template.pm
@@ -28,13 +28,16 @@ sub AUTOLOAD {
     my $self = shift;
     $AUTOLOAD =~ s/(?:(.*)::)?(.+)//;
     my ($p, $m) = ($1, $2);
+    my $has_attr;
     foreach my $obj ($self->objects) {
 	if ($obj->can($m)) {
+	    $has_attr = 1;
 	    if (defined(my $v = $obj->${\$m}(@_))) {
 		return $v;
 	    }
 	}
     }
+    return if $has_attr;
     croak "Can't locate object method \"$m\" via package \"$p\"";
 }
 

--- a/t/additive_inheritance.cfg
+++ b/t/additive_inheritance.cfg
@@ -1,0 +1,17 @@
+# An example of additive inheritance from
+# https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectinheritance.html#add_string
+#
+define host {
+	name			generichosttemplate
+	hostgroups		all-servers
+	register		0
+}
+
+define host {
+	host_name		linuxserver1
+	hostgroups		+linux-servers,web-servers
+        use			generichosttemplate
+}
+
+# The effective value of hostgroups in linuxserver1 is
+#  all-servers,linux-servers,web-servers

--- a/t/additive_inheritance.t
+++ b/t/additive_inheritance.t
@@ -1,0 +1,21 @@
+#!/usr/bin/perl -w
+
+use strict;
+use Test::More qw(no_plan);
+use Test::NoWarnings;
+use lib qw( ../lib ./lib );
+use Data::Dumper;
+
+$Data::Dumper::Terse = 1;
+$Data::Dumper::Indent = 0;
+
+eval { chdir('t') };
+
+use Nagios::Config;
+
+my $config = Nagios::Object::Config->new();
+$config->parse('additive_inheritance.cfg');
+
+my $host = $config->find_object('linuxserver1','Nagios::Host');
+is(Dumper([$host->hostgroups]),q{[['all-servers','linux-servers','web-servers']]});
+

--- a/t/multipletemplates.cfg
+++ b/t/multipletemplates.cfg
@@ -23,3 +23,30 @@ define host {
 	host_name 		devweb1
 }
 
+#
+# A combination of multiple template and additive inheritance.
+#
+define host {
+	name			generichosttemplate
+	hostgroups		all-servers
+	register		0
+}
+
+define host {
+	name			template1
+	hostgroups		+linux-servers,web-servers
+        use			generichosttemplate
+}
+
+define host {
+	name			template2
+	hostgroups		another
+}
+
+define host {
+	host_name		linuxserver2
+	use			template1,template2
+	hostgroups		+one
+}
+
+

--- a/t/multipletemplates.t
+++ b/t/multipletemplates.t
@@ -23,3 +23,8 @@ is($host->active_checks_enabled, 1, 'attribute defined in first parent template'
 is(Dumper([$host->notification_options]), q{[['d','u','r']]},
    'attribute defined in second parent template');
 
+$host = $config->find_object('linuxserver2','Nagios::Host');
+is(Dumper([$host->hostgroups]), q{[['all-servers','linux-servers','web-servers','one']]},
+    'multiple additive inheritance');
+
+is($host->alias, undef, 'undefined attribute');


### PR DESCRIPTION
This commit adds support for additive inheritance as per https://assets.nagios.com/downloads/nagioscore/docs/nagioscore3/en/objectinheritance.html#add_string and fixes a bug in the multiple inheritance implementation (proper return in case of valid, but undefined Nagios variable).

* lib/Nagios/Object.pm (_set): Register additive attributes in
the {_additive} hash.
(_make_method) <get>: Implement additive inheritance.
* t/additive_inheritance.cfg: New test config.
* t/additive_inheritance.t: New testcase.

* lib/Nagios/Template.pm (AUTOLOAD): Don't croak on undefined,
but valid attributes.  Return undef as expected.

* t/multipletemplates.cfg: Add a sample of multiple additive
inheritance.
* t/multipletemplates.t: Check for the proper return of undefined
attribute and for working multiple additive inheritance.